### PR TITLE
fix: overlay showing when meant to be hidden

### DIFF
--- a/SpellOverlay Enhanced.lua
+++ b/SpellOverlay Enhanced.lua
@@ -347,6 +347,13 @@ function SOE:EnsureHelperExists(overlay)
     end
 end
 
+-- Move offscreen to bypass fade-in animations overriding alpha.
+function SOE:HideOverlay(overlay)
+    overlay:ClearAllPoints()
+    overlay:SetPoint("BOTTOMRIGHT", UIParent, "TOPLEFT", -10000, 10000)
+    if overlay.SOE_Glow then overlay.SOE_Glow:Hide() end
+end
+
 function SOE:ApplyToOverlay(overlay)
     if not overlay:IsShown() then 
         if overlay.SOE_Glow then overlay.SOE_Glow:Hide() end
@@ -377,8 +384,7 @@ function SOE:ApplyToOverlay(overlay)
             end
             
             if isSuppressed then
-                mainTexture:SetAlpha(0)
-                if overlay.SOE_Glow then overlay.SOE_Glow:Hide() end
+                SOE:HideOverlay(overlay)
                 return
             end
         end
@@ -480,6 +486,11 @@ function SOE:ApplyToOverlay(overlay)
 
     local baseAlpha = (isRightSide and isDualProc) and (settings.alpha2 or 1.0) or (settings.alpha or 1.0)
     local finalAlpha = baseAlpha * pulseFactor
+
+    if finalAlpha <= 0 then
+        SOE:HideOverlay(overlay)
+        return
+    end
 
     -- [5] APPLY SCALE & POSITION
     local scale = settings.scale or 1.0


### PR DESCRIPTION
I use the addon to hide the right-side proc texture, and it sometimes flashes at 100% incorrectly. If the alpha setting is 0 (to hide it), we can just move the overlay offscreen to fix the issue. 